### PR TITLE
Removes BOM from schema files before parsing

### DIFF
--- a/lib/schema-loaders/custom-loader.js
+++ b/lib/schema-loaders/custom-loader.js
@@ -25,14 +25,18 @@ module.exports = class CustomSchemaLoader extends EventEmitter {
 
         if (this.schemaPath.match(/\.ya?ml$/)) {
             try {
-                customSchema = YAML.load(fs.readFileSync(this.schemaPath));
+                // Remove BOM if present
+                const cleansedContent = fs.readFileSync(this.schemaPath, 'utf8').replace(/^\uFEFF/, '');
+                customSchema = YAML.load(cleansedContent);
             } catch (e) {
                 throw new OpenAPISchemaMalformed(e.message);
             }
         }
 
         try {
-            customSchema = JSON.parse(fs.readFileSync(this.schemaPath));
+            // Remove BOM if present
+            const cleansedContent = fs.readFileSync(this.schemaPath, 'utf8').replace(/^\uFEFF/, '');
+            customSchema = JSON.parse(cleansedContent);
         } catch (e) {
             throw new OpenAPISchemaMalformed(e.message);
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "open-api-mocker",
-  "version": "2.0.0",
+  "name": "@coductsolutions/open-api-mocker",
+  "version": "1.0.26",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "open-api-mocker",
-      "version": "2.0.0",
+      "name": "@coductsolutions/open-api-mocker",
+      "version": "1.0.26",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^8.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coductsolutions/open-api-mocker",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "description": "A mock server based in Open API Specification",
   "main": "lib/open-api-mocker.js",
   "bin": {


### PR DESCRIPTION
Ensures that Byte Order Marks (BOM) are removed from schema files before parsing them as either YAML or JSON. This prevents parsing errors caused by the presence of a BOM at the beginning of the file.

Also, updates the package version.
